### PR TITLE
Fix price oracle (cumulative prices) for pair contract

### DIFF
--- a/uniswap-v2/logics/Cargo.toml
+++ b/uniswap-v2/logics/Cargo.toml
@@ -16,7 +16,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 openbrush = { version = "2.2.0", default-features = false, features = ["psp22", "ownable", "reentrancy_guard"] }
-primitive-types = { version = "0.11.1", default-features = false, features = ["num-traits"] }
+primitive-types = { version = "0.11.1", default-features = false, features = ["codec"] }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28"}
 
 [lib]

--- a/uniswap-v2/logics/Cargo.toml
+++ b/uniswap-v2/logics/Cargo.toml
@@ -17,6 +17,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 
 openbrush = { version = "2.2.0", default-features = false, features = ["psp22", "ownable", "reentrancy_guard"] }
 primitive-types = { version = "0.11.1", default-features = false, features = ["num-traits"] }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.28"}
 
 [lib]
 name = "uniswap_v2"
@@ -38,5 +39,7 @@ std = [
     "scale-info",
     "scale-info/std",
     "openbrush/std",
-    "primitive-types/std"
+    "primitive-types/std",
+    "primitive-types/scale-info",
+    "sp-arithmetic/std"
 ]

--- a/uniswap-v2/logics/impls/pair/data.rs
+++ b/uniswap-v2/logics/impls/pair/data.rs
@@ -1,3 +1,4 @@
+use crate::traits::pair::WrappedU256;
 use openbrush::traits::{
     AccountId,
     Balance,
@@ -15,8 +16,8 @@ pub struct Data {
     pub reserve_0: Balance,
     pub reserve_1: Balance,
     pub block_timestamp_last: Timestamp,
-    pub price_0_cumulative_last: Balance,
-    pub price_1_cumulative_last: Balance,
+    pub price_0_cumulative_last: WrappedU256,
+    pub price_1_cumulative_last: WrappedU256,
     pub k_last: u128,
     pub lock: bool,
 }

--- a/uniswap-v2/logics/impls/pair/data.rs
+++ b/uniswap-v2/logics/impls/pair/data.rs
@@ -1,4 +1,4 @@
-use crate::traits::pair::WrappedU256;
+use crate::traits::types::WrappedU256;
 use openbrush::traits::{
     AccountId,
     Balance,

--- a/uniswap-v2/logics/impls/pair/pair.rs
+++ b/uniswap-v2/logics/impls/pair/pair.rs
@@ -1,4 +1,7 @@
-use crate::traits::{factory::FactoryRef, types::WrappedU256};
+use crate::traits::{
+    factory::FactoryRef,
+    types::WrappedU256,
+};
 pub use crate::{
     impls::pair::*,
     traits::pair::*,
@@ -23,8 +26,9 @@ use openbrush::{
 };
 use primitive_types::U256;
 use sp_arithmetic::{
+    traits::IntegerSquareRoot,
     FixedPointNumber,
-    FixedU128, traits::IntegerSquareRoot,
+    FixedU128,
 };
 
 pub const MINIMUM_LIQUIDITY: u128 = 1000;
@@ -83,7 +87,8 @@ impl<
             let liq = amount_0
                 .checked_mul(amount_1)
                 .ok_or(PairError::MulOverFlow1)?;
-            liquidity = liq.integer_sqrt()
+            liquidity = liq
+                .integer_sqrt()
                 .checked_sub(MINIMUM_LIQUIDITY)
                 .ok_or(PairError::SubUnderFlow3)?;
             self._mint(ZERO_ADDRESS.into(), MINIMUM_LIQUIDITY)?;
@@ -343,7 +348,8 @@ impl<
             if k_last != 0 {
                 let root_k = reserve_0
                     .checked_mul(reserve_1)
-                    .ok_or(PairError::MulOverFlow14)?.integer_sqrt();
+                    .ok_or(PairError::MulOverFlow14)?
+                    .integer_sqrt();
                 let root_k_last = k_last.integer_sqrt();
                 if root_k > root_k_last {
                     let total_supply = self.data::<psp22::Data>().supply;

--- a/uniswap-v2/logics/impls/pair/pair.rs
+++ b/uniswap-v2/logics/impls/pair/pair.rs
@@ -1,4 +1,4 @@
-use crate::traits::factory::FactoryRef;
+use crate::traits::{factory::FactoryRef, types::WrappedU256};
 pub use crate::{
     impls::pair::*,
     traits::pair::*,

--- a/uniswap-v2/logics/traits/mod.rs
+++ b/uniswap-v2/logics/traits/mod.rs
@@ -1,5 +1,5 @@
 pub mod factory;
 pub mod math;
-pub mod types;
 pub mod pair;
 pub mod router;
+pub mod types;

--- a/uniswap-v2/logics/traits/mod.rs
+++ b/uniswap-v2/logics/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod factory;
 pub mod math;
+pub mod types;
 pub mod pair;
 pub mod router;

--- a/uniswap-v2/logics/traits/pair.rs
+++ b/uniswap-v2/logics/traits/pair.rs
@@ -13,28 +13,8 @@ use openbrush::{
         Timestamp,
     },
 };
-use primitive_types::U256;
 
-#[cfg(feature = "std")]
-use ink_metadata::layout::{
-    CellLayout,
-    Layout,
-    LayoutKey,
-};
-use ink_primitives::KeyPtr;
-use ink_storage::traits::{
-    ExtKeyPtr,
-    PackedLayout,
-    SpreadAllocate,
-    SpreadLayout,
-};
-
-#[cfg(feature = "std")]
-use ink_storage::traits::StorageLayout;
-use scale::{
-    Decode,
-    Encode,
-};
+use super::types::WrappedU256;
 
 #[openbrush::wrapper]
 pub type PairRef = dyn Pair;
@@ -193,85 +173,3 @@ impl From<ReentrancyGuardError> for PairError {
         PairError::ReentrancyGuardError(error)
     }
 }
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
-#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-pub struct WrappedU256(U256);
-impl SpreadLayout for WrappedU256 {
-    const FOOTPRINT: u64 = 4;
-    const REQUIRES_DEEP_CLEAN_UP: bool = true;
-    fn pull_spread(ptr: &mut ink_primitives::KeyPtr) -> Self {
-        let slice: [u64; 4] = SpreadLayout::pull_spread(ptr);
-        Self(U256(slice))
-    }
-
-    fn push_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
-        SpreadLayout::push_spread(&self.0 .0, ptr);
-    }
-
-    fn clear_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
-        SpreadLayout::clear_spread(&self.0 .0, ptr);
-    }
-}
-
-impl PackedLayout for WrappedU256 {
-    fn pull_packed(&mut self, at: &ink_primitives::Key) {
-        self.0 .0.pull_packed(at);
-    }
-    fn push_packed(&self, at: &ink_primitives::Key) {
-        self.0 .0.push_packed(at);
-    }
-    fn clear_packed(&self, at: &ink_primitives::Key) {
-        self.0 .0.clear_packed(at);
-    }
-}
-
-impl SpreadAllocate for WrappedU256 {
-    fn allocate_spread(ptr: &mut KeyPtr) -> Self {
-        ptr.next_for::<WrappedU256>();
-        WrappedU256::default()
-    }
-}
-
-#[cfg(feature = "std")]
-impl StorageLayout for WrappedU256 {
-    fn layout(key_ptr: &mut KeyPtr) -> Layout {
-        Layout::Cell(CellLayout::new::<WrappedU256>(LayoutKey::from(
-            key_ptr.advance_by(1),
-        )))
-    }
-}
-
-impl From<WrappedU256> for U256 {
-    fn from(value: WrappedU256) -> Self {
-        value.0
-    }
-}
-
-impl From<U256> for WrappedU256 {
-    fn from(value: U256) -> Self {
-        WrappedU256(value)
-    }
-}
-
-macro_rules! construct_from {
-    ( $( $type:ident ),* ) => {
-        $(
-            impl TryFrom<WrappedU256> for $type {
-                type Error = &'static str;
-                #[inline]
-                fn try_from(value: WrappedU256) -> Result<Self, Self::Error> {
-                    Self::try_from(value.0)
-                }
-            }
-
-            impl From<$type> for WrappedU256 {
-                fn from(value: $type) -> WrappedU256 {
-                    WrappedU256(U256::from(value))
-                }
-            }
-        )*
-    };
-}
-
-construct_from!(u8, u16, u32, u64, usize, i8, i16, i32, i64);

--- a/uniswap-v2/logics/traits/pair.rs
+++ b/uniswap-v2/logics/traits/pair.rs
@@ -13,6 +13,28 @@ use openbrush::{
         Timestamp,
     },
 };
+use primitive_types::U256;
+
+#[cfg(feature = "std")]
+use ink_metadata::layout::{
+    CellLayout,
+    Layout,
+    LayoutKey,
+};
+use ink_primitives::KeyPtr;
+use ink_storage::traits::{
+    ExtKeyPtr,
+    PackedLayout,
+    SpreadAllocate,
+    SpreadLayout,
+};
+
+#[cfg(feature = "std")]
+use ink_storage::traits::StorageLayout;
+use scale::{
+    Decode,
+    Encode,
+};
 
 #[openbrush::wrapper]
 pub type PairRef = dyn Pair;
@@ -21,6 +43,12 @@ pub type PairRef = dyn Pair;
 pub trait Pair {
     #[ink(message)]
     fn get_reserves(&self) -> (Balance, Balance, Timestamp);
+
+    #[ink(message)]
+    fn price_0_cumulative_last(&self) -> WrappedU256;
+
+    #[ink(message)]
+    fn price_1_cumulative_last(&self) -> WrappedU256;
 
     #[ink(message)]
     fn initialize(&mut self, token_0: AccountId, token_1: AccountId) -> Result<(), PairError>;
@@ -165,3 +193,85 @@ impl From<ReentrancyGuardError> for PairError {
         PairError::ReentrancyGuardError(error)
     }
 }
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct WrappedU256(U256);
+impl SpreadLayout for WrappedU256 {
+    const FOOTPRINT: u64 = 4;
+    const REQUIRES_DEEP_CLEAN_UP: bool = true;
+    fn pull_spread(ptr: &mut ink_primitives::KeyPtr) -> Self {
+        let slice: [u64; 4] = SpreadLayout::pull_spread(ptr);
+        Self(U256(slice))
+    }
+
+    fn push_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
+        SpreadLayout::push_spread(&self.0 .0, ptr);
+    }
+
+    fn clear_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
+        SpreadLayout::clear_spread(&self.0 .0, ptr);
+    }
+}
+
+impl PackedLayout for WrappedU256 {
+    fn pull_packed(&mut self, at: &ink_primitives::Key) {
+        self.0 .0.pull_packed(at);
+    }
+    fn push_packed(&self, at: &ink_primitives::Key) {
+        self.0 .0.push_packed(at);
+    }
+    fn clear_packed(&self, at: &ink_primitives::Key) {
+        self.0 .0.clear_packed(at);
+    }
+}
+
+impl SpreadAllocate for WrappedU256 {
+    fn allocate_spread(ptr: &mut KeyPtr) -> Self {
+        ptr.next_for::<WrappedU256>();
+        WrappedU256::default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl StorageLayout for WrappedU256 {
+    fn layout(key_ptr: &mut KeyPtr) -> Layout {
+        Layout::Cell(CellLayout::new::<WrappedU256>(LayoutKey::from(
+            key_ptr.advance_by(1),
+        )))
+    }
+}
+
+impl From<WrappedU256> for U256 {
+    fn from(value: WrappedU256) -> Self {
+        value.0
+    }
+}
+
+impl From<U256> for WrappedU256 {
+    fn from(value: U256) -> Self {
+        WrappedU256(value)
+    }
+}
+
+macro_rules! construct_from {
+    ( $( $type:ident ),* ) => {
+        $(
+            impl TryFrom<WrappedU256> for $type {
+                type Error = &'static str;
+                #[inline]
+                fn try_from(value: WrappedU256) -> Result<Self, Self::Error> {
+                    Self::try_from(value.0)
+                }
+            }
+
+            impl From<$type> for WrappedU256 {
+                fn from(value: $type) -> WrappedU256 {
+                    WrappedU256(U256::from(value))
+                }
+            }
+        )*
+    };
+}
+
+construct_from!(u8, u16, u32, u64, usize, i8, i16, i32, i64);

--- a/uniswap-v2/logics/traits/types.rs
+++ b/uniswap-v2/logics/traits/types.rs
@@ -1,0 +1,105 @@
+use primitive_types::U256;
+
+#[cfg(feature = "std")]
+use ink_metadata::layout::{
+    CellLayout,
+    Layout,
+    LayoutKey,
+};
+use ink_primitives::KeyPtr;
+use ink_storage::traits::{
+    ExtKeyPtr,
+    PackedLayout,
+    SpreadAllocate,
+    SpreadLayout,
+};
+
+#[cfg(feature = "std")]
+use ink_storage::traits::StorageLayout;
+use scale::{
+    Decode,
+    Encode,
+};
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct WrappedU256(U256);
+
+impl SpreadLayout for WrappedU256 {
+    const FOOTPRINT: u64 = 4;
+    const REQUIRES_DEEP_CLEAN_UP: bool = true;
+    fn pull_spread(ptr: &mut ink_primitives::KeyPtr) -> Self {
+        let slice: [u64; 4] = SpreadLayout::pull_spread(ptr);
+        Self(U256(slice))
+    }
+
+    fn push_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
+        SpreadLayout::push_spread(&self.0 .0, ptr);
+    }
+
+    fn clear_spread(&self, ptr: &mut ink_primitives::KeyPtr) {
+        SpreadLayout::clear_spread(&self.0 .0, ptr);
+    }
+}
+
+impl PackedLayout for WrappedU256 {
+    fn pull_packed(&mut self, at: &ink_primitives::Key) {
+        self.0 .0.pull_packed(at);
+    }
+    fn push_packed(&self, at: &ink_primitives::Key) {
+        self.0 .0.push_packed(at);
+    }
+    fn clear_packed(&self, at: &ink_primitives::Key) {
+        self.0 .0.clear_packed(at);
+    }
+}
+
+impl SpreadAllocate for WrappedU256 {
+    fn allocate_spread(ptr: &mut KeyPtr) -> Self {
+        ptr.next_for::<WrappedU256>();
+        WrappedU256::default()
+    }
+}
+
+#[cfg(feature = "std")]
+impl StorageLayout for WrappedU256 {
+    fn layout(key_ptr: &mut KeyPtr) -> Layout {
+        Layout::Cell(CellLayout::new::<WrappedU256>(LayoutKey::from(
+            key_ptr.advance_by(1),
+        )))
+    }
+}
+
+impl From<WrappedU256> for U256 {
+    fn from(value: WrappedU256) -> Self {
+        value.0
+    }
+}
+
+impl From<U256> for WrappedU256 {
+    fn from(value: U256) -> Self {
+        WrappedU256(value)
+    }
+}
+
+macro_rules! construct_from {
+    ( $( $type:ident ),* ) => {
+        $(
+            impl TryFrom<WrappedU256> for $type {
+                type Error = &'static str;
+                #[inline]
+                fn try_from(value: WrappedU256) -> Result<Self, Self::Error> {
+                    Self::try_from(value.0)
+                }
+            }
+
+            impl From<$type> for WrappedU256 {
+                fn from(value: $type) -> WrappedU256 {
+                    WrappedU256(U256::from(value))
+                }
+            }
+        )*
+    };
+}
+
+construct_from!(u8, u16, u32, u64, usize, i8, i16, i32, i64);


### PR DESCRIPTION
- Introduce U256 as cumulative price type
- Use integer sqrt over custum sqrt
- Add simple off chain test for cumulative price function (factored out core function)
- Previously, it used integer division to compute it, which ends up incorrect prices.
  By adopting FixedU128, changed to fixed point division, hence avoiding precision problem.
  See, https://github.com/AstarNetwork/wasm-showcase-dapps/commit/9483457dd418d1c7a914dba4acaf652d5fd23bbb#r83105327

Is also a good showcase how to use custom type in Ink! (WrappedU256)