### PR TITLE
Make pair_for method internal call

### DIFF
--- a/tests/router.ts
+++ b/tests/router.ts
@@ -20,7 +20,7 @@ describe('ROUTER', () => {
         const match = tokenA.contract.address.toString() == token0Address.output.toString()
         const token0 = match ? tokenA : tokenB
         const token1 = match ? tokenB : tokenA
-        const router_contract = await setupContract('router_contract', 'new', factory_contract.contract.address)
+        const router_contract = await setupContract('router_contract', 'new', factory_contract.contract.address, pair_code_hash)
 
         return {
             wallet,

--- a/uniswap-v2/contracts/router/lib.rs
+++ b/uniswap-v2/contracts/router/lib.rs
@@ -21,9 +21,10 @@ pub mod router {
 
     impl RouterContract {
         #[ink(constructor)]
-        pub fn new(factory: AccountId) -> Self {
+        pub fn new(factory: AccountId, pair_code_hash: Hash) -> Self {
             ink_lang::codegen::initialize_contract(|instance: &mut Self| {
                 instance.router.factory = factory;
+                instance.router.pair_code_hash = pair_code_hash;
             })
         }
     }

--- a/uniswap-v2/logics/impls/router/data.rs
+++ b/uniswap-v2/logics/impls/router/data.rs
@@ -7,6 +7,5 @@ pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(Data);
 #[openbrush::upgradeable_storage(STORAGE_KEY)]
 pub struct Data {
     pub factory: AccountId,
-    // TODO: remove pair code hash as like https://github.com/Uniswap/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L18
     pub pair_code_hash: Hash,
 }

--- a/uniswap-v2/logics/impls/router/data.rs
+++ b/uniswap-v2/logics/impls/router/data.rs
@@ -1,3 +1,4 @@
+use ink_env::Hash;
 use openbrush::traits::AccountId;
 
 pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(Data);
@@ -6,4 +7,6 @@ pub const STORAGE_KEY: u32 = openbrush::storage_unique_key!(Data);
 #[openbrush::upgradeable_storage(STORAGE_KEY)]
 pub struct Data {
     pub factory: AccountId,
+    // TODO: remove pair code hash as like https://github.com/Uniswap/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L18
+    pub pair_code_hash: Hash,
 }

--- a/uniswap-v2/logics/impls/router/router.rs
+++ b/uniswap-v2/logics/impls/router/router.rs
@@ -426,13 +426,18 @@ impl<T: Storage<data::Data>> Router for T {
         Ok(())
     }
 
+    /// Original Uniswap Library pairFor function calculate pair contract address without making cross contract calls.
+    /// Please refer https://github.com/Uniswap/v2-periphery/blob/master/contracts/libraries/UniswapV2Library.sol#L18
+    ///
+    /// In this contract, use precomputed address like Uniswap's, as ink!'s deployment is done via create2-like one by default.
+    /// Please refer https://github.com/paritytech/substrate/blob/493b58bd4a475080d428ce47193ee9ea9757a808/frame/contracts/src/lib.rs#L178
+    /// for how contract's address is calculated.
     default fn _pair_for(
         &self,
         factory: AccountId,
         token_a: AccountId,
         token_b: AccountId,
     ) -> Result<AccountId, RouterError> {
-        // TODO: remove pair code hash after deployment
         let tokens = self._sort_tokens(token_a, token_b)?;
         let salt = &Self::env().hash_encoded::<Blake2x256, _>(&tokens)[..4];
         let input: Vec<_> = AsRef::<[u8]>::as_ref(&factory)


### PR DESCRIPTION
Resolves #19

A good showcase how to calculate contract address even before corresponding contract gets deployed, like create2 of EVM.