### PR TITLE
Fix corrupted implementations in router

### DIFF
--- a/uniswap-v2/logics/impls/router/router.rs
+++ b/uniswap-v2/logics/impls/router/router.rs
@@ -182,7 +182,7 @@ impl<T: Storage<data::Data>> Router for T {
             Vec::new(),
         )?;
 
-        self._swap(amounts.clone(), path, to)?;
+        self._swap(&amounts, path, to)?;
 
         Ok(amounts)
     }
@@ -211,7 +211,7 @@ impl<T: Storage<data::Data>> Router for T {
             Vec::new(),
         )?;
 
-        self._swap(amounts.clone(), path, to)?;
+        self._swap(&amounts, path, to)?;
 
         Ok(amounts)
     }
@@ -387,7 +387,7 @@ impl<T: Storage<data::Data>> Router for T {
 
     default fn _swap(
         &mut self,
-        amounts: Vec<Balance>,
+        amounts: &Vec<Balance>,
         path: Vec<AccountId>,
         to: AccountId,
     ) -> Result<(), RouterError> {

--- a/uniswap-v2/logics/impls/router/router.rs
+++ b/uniswap-v2/logics/impls/router/router.rs
@@ -303,7 +303,7 @@ impl<T: Storage<data::Data>> Router for T {
         let mut amounts = Vec::with_capacity(path.len());
         amounts[path.len() - 1] = amount_out;
         for i in (0..path.len() - 1).rev() {
-            let (reserve_in, reserve_out) = self._get_reserves(factory, path[i + 1], path[i])?;
+            let (reserve_in, reserve_out) = self._get_reserves(factory, path[i], path[i + 1])?;
             amounts[i] = self.get_amount_in(amounts[i + 1], reserve_in, reserve_out)?;
         }
 

--- a/uniswap-v2/logics/traits/router.rs
+++ b/uniswap-v2/logics/traits/router.rs
@@ -199,8 +199,6 @@ pub enum RouterError {
     SubUnderFlow1,
     MulOverFlow1,
     MulOverFlow2,
-    MulOverFlow3,
-    MulOverFlow4,
     DivByZero1,
     DivByZero2,
     DivByZero3,

--- a/uniswap-v2/logics/traits/router.rs
+++ b/uniswap-v2/logics/traits/router.rs
@@ -149,7 +149,7 @@ pub trait Router {
 
     fn _swap(
         &mut self,
-        amounts: Vec<Balance>,
+        amounts: &Vec<Balance>,
         path: Vec<AccountId>,
         to: AccountId,
     ) -> Result<(), RouterError>;


### PR DESCRIPTION
- ONE should be 1 not 1e18
- the loop in get_amounts_in should go descending order
- Balance multiplications should be casted to U256
- Remove unnecessary clone